### PR TITLE
4 hook

### DIFF
--- a/contracts/SubscriptionsManagerFactory.sol
+++ b/contracts/SubscriptionsManagerFactory.sol
@@ -82,7 +82,7 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
     * @param price price for subsription on single interval
     * @param controller [optional] controller address
     * @param recipient address which will obtain pay for subscription
-    * @param recipientImplementsHooks if true then contract expected recipient as contract and will try to call ISubscriptionsHook(recipient).onCharge
+    * @param hook address if present  then contract will try to call ISubscriptionsHook(hook).onCharge
     * @return instance address of created instance `SubscriptionsManager`
     * @custom:shortd creation SubscriptionsManager instance
     */
@@ -95,13 +95,13 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
         uint256 price,
         address controller,
         address recipient,
-        bool recipientImplementsHooks
+        address hook
     ) 
         public 
         returns (address instance) 
     {
         instance = address(implementation).clone();
-        _produce(instance, interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, recipientImplementsHooks);
+        _produce(instance, interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, hook);
     }
 
     /**
@@ -113,7 +113,7 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
     * @param price price for subsription on single interval
     * @param controller [optional] controller address
     * @param recipient address which will obtain pay for subscription
-    * @param recipientImplementsHooks if true then contract expected recipient as contract and will try to call ISubscriptionsHook(recipient).onCharge
+    * @param hook address if present  then contract will try to call ISubscriptionsHook(hook).onCharge
     * @return instance address of created instance `SubscriptionsManager`
     * @custom:shortd creation SubscriptionsManager instance
     */
@@ -127,13 +127,13 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
         uint256 price,
         address controller,
         address recipient,
-        bool recipientImplementsHooks
+        address hook
     ) 
         public 
         returns (address instance) 
     {
         instance = address(implementation).cloneDeterministic(salt);
-        _produce(instance, interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, recipientImplementsHooks);
+        _produce(instance, interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, hook);
     }
 
     function doCharge(
@@ -184,7 +184,7 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
         uint256 price,
         address controller,
         address recipient,
-        bool recipientImplementsHooks
+        address hook
     ) 
         internal
     {
@@ -206,7 +206,7 @@ contract SubscriptionsManagerFactory  is CostManagerFactoryHelper, ReleaseManage
         }
     
         //initialize
-        ISubscriptionsManagerUpgradeable(instance).initialize(interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, recipientImplementsHooks, costManager, msg.sender);
+        ISubscriptionsManagerUpgradeable(instance).initialize(interval, intervalsMax, intervalsMin, retries, token, price, controller, recipient, hook, costManager, msg.sender);
 
         //after initialize
         Ownable(instance).transferOwnership(msg.sender);

--- a/contracts/SubscriptionsManagerUpgradeable.sol
+++ b/contracts/SubscriptionsManagerUpgradeable.sol
@@ -19,7 +19,7 @@ contract SubscriptionsManagerUpgradeable is OwnableUpgradeable, ISubscriptionsMa
     uint256 public price; // the price to charge
 
     address recipient;
-    bool recipientImplementsHooks; // whether recipient is a contract that implements onTransfer, etc.
+    address hook;
 
     mapping (address => Subscription) public subscriptions;
     mapping (address => bool) public callers;
@@ -69,7 +69,7 @@ contract SubscriptionsManagerUpgradeable is OwnableUpgradeable, ISubscriptionsMa
     * @param price_ price for subsription on single interval
     * @param controller_ [optional] controller address
     * @param recipient_ address which will obtain pay for subscription
-    * @param recipientImplementsHooks_ if true then contract expected recipient as contract and will try to call ISubscriptionsHook(recipient).onCharge
+    * @param hook_  if present then try to call hook.onCharge 
     * @param costManager_ costManager address
     * @param producedBy_ producedBy address
     * @custom:calledby factory
@@ -84,7 +84,7 @@ contract SubscriptionsManagerUpgradeable is OwnableUpgradeable, ISubscriptionsMa
         uint256 price_,
         address controller_,
         address recipient_,
-        bool recipientImplementsHooks_,
+        address hook_,
         address costManager_,
         address producedBy_
     ) 
@@ -109,7 +109,7 @@ contract SubscriptionsManagerUpgradeable is OwnableUpgradeable, ISubscriptionsMa
         price = price_;
         controller = controller_;
         recipient = recipient_;
-        recipientImplementsHooks = recipientImplementsHooks_;
+        hook = hook_;
 
         _accountForOperation(
             OPERATION_INITIALIZE << OPERATION_SHIFT_BITS,
@@ -309,8 +309,8 @@ contract SubscriptionsManagerUpgradeable is OwnableUpgradeable, ISubscriptionsMa
                 subscription.endTime += interval * desiredIntervals;
                 count++;
 
-                if (recipientImplementsHooks) {
-                    ISubscriptionsHook(recipient).onCharge(token, getSubscriptionPrice(subscription));
+                if (hook != address(0)) {
+                    ISubscriptionsHook(hook).onCharge(token, getSubscriptionPrice(subscription));
                 }
             } else {
                 if (subscription.state != SubscriptionState.EXPIRED) {

--- a/contracts/interfaces/ISubscriptionsManagerUpgradeable.sol
+++ b/contracts/interfaces/ISubscriptionsManagerUpgradeable.sol
@@ -44,7 +44,7 @@ interface ISubscriptionsManagerUpgradeable {
         uint256 price,
         address controller,
         address recipient,
-        bool recipientImplementsHooks,
+        address hook,
         address costManager,
         address producedBy
     ) external;

--- a/contracts/mocks/MockSubscriptionsHook.sol
+++ b/contracts/mocks/MockSubscriptionsHook.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import "../interfaces/ISubscriptionsHook.sol";
+
+contract MockSubscriptionsHook is ISubscriptionsHook {
+    bool public chargeCallbackTriggered = false;
+    function onCharge(address token, uint256 amount) external {
+        chargeCallbackTriggered = true;
+    }
+
+}

--- a/contracts/mocks/MockSubscriptionsHookBad.sol
+++ b/contracts/mocks/MockSubscriptionsHookBad.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.11;
 
 import "../interfaces/ISubscriptionsHook.sol";
 
-contract MockRecipientHook is ISubscriptionsHook {
-    bool public chargeCallbackTriggered = false;
+contract MockSubscriptionsHookBad is ISubscriptionsHook {
+    error HappensSmthUnexpected();
+    
     function onCharge(address token, uint256 amount) external {
-        chargeCallbackTriggered = true;
+        revert HappensSmthUnexpected();
     }
 
 }

--- a/contracts/mocks/MockSubscriptionsHookBad.sol
+++ b/contracts/mocks/MockSubscriptionsHookBad.sol
@@ -5,7 +5,7 @@ import "../interfaces/ISubscriptionsHook.sol";
 
 contract MockSubscriptionsHookBad is ISubscriptionsHook {
     error HappensSmthUnexpected();
-    
+    bool public chargeCallbackTriggered = false;
     function onCharge(address token, uint256 amount) external {
         revert HappensSmthUnexpected();
     }

--- a/contracts/mocks/MockSubscriptionsManagerUpgradeable.sol
+++ b/contracts/mocks/MockSubscriptionsManagerUpgradeable.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.11;
 import "../SubscriptionsManagerUpgradeable.sol";
 
 contract MockSubscriptionsManagerUpgradeable is SubscriptionsManagerUpgradeable {
-    function setRecipientImplementsHooks(bool b) public {
-        recipientImplementsHooks = b;
+    function setHook(address hook_) public {
+        hook = hook_;
     }
 
     function setRecipient(address addr) public {


### PR DESCRIPTION
replace `recipientImplementsHooks`  for `hook address`
now recipient can not be a contract and onChange can be implemented only in the hook. hook should implement ISubscriptionsHook
```
interface ISubscriptionsHook {
    function onCharge(address token, uint256 amount) external;
}
```
